### PR TITLE
Non max suppression for line extraction

### DIFF
--- a/gluefactory/models/lines/line_refinement.py
+++ b/gluefactory/models/lines/line_refinement.py
@@ -165,7 +165,9 @@ def merge_lines_torch(lines, thresh=5.0, overlap_thresh=0.0, return_indices=Fals
     Two lines are merged when their orthogonal distance is smaller
     than a threshold and they have a positive overlap.
     Args:
-        lines: a (N, 2, 2) torch tensor.
+        lines: a (N, 2, 2) torch tensor if return_indices is False, otherwise
+                a (N, 2, 3) torch tensor. The first two channels are the line endpoints,
+                the third channel is the index of the keypoints.
         thresh: maximum orthogonal distance between two lines to be merged.
         overlap_thresh: maximum distance between 2 endpoints to merge
                         two aligned lines.

--- a/gluefactory/models/lines/line_refinement.py
+++ b/gluefactory/models/lines/line_refinement.py
@@ -65,7 +65,9 @@ def merge_line_cluster_torch(lines, return_indices=False):
     endpoints barycenter, project the endpoints onto the middle line,
     keep the two extreme projections.
     Args:
-        lines: a (n, 2, 3) torch tensor containing n lines (with keypoint indices).
+        lines: a (N, 2, 2) torch tensor if return_indices is False, otherwise
+                a (N, 2, 3) torch tensor where the first two channels are the line endpoints,
+                the third channel is the index of the keypoints.
     Returns:
         The merged (2, 2) torch tensor line segment.
     """

--- a/gluefactory/models/lines/pold2_extractor.py
+++ b/gluefactory/models/lines/pold2_extractor.py
@@ -269,39 +269,58 @@ def test_extractor(extractor, folder_path, device, show=False):
     # End counter
     end_time = time.perf_counter()
 
-    measure = False
-    if measure:
-        print(f"{1000*(end_time - start_time)}")
-    else:
-        plt.figure()
+    image = image.cpu().detach().numpy()
+    points = points.cpu().numpy()
+    indices_image = indices_image.cpu().numpy()
 
-        image = image.cpu().detach().numpy()
-        points = points.cpu().numpy()
-        indices_image = indices_image.cpu().numpy()
+    # Samples lines from indices
+    lines = points[indices_image]
 
-        # Samples lines from indices
-        lines = points[indices_image]
+    # Append indices to lines - (N,2,3)
+    lines = np.concatenate([lines.reshape(-1,2), indices_image.reshape(-1,1)], axis=-1).reshape(-1, 2, 3)
 
-        # Apply non-max suppresion on lines - GPU implementation from deeplsd
-        # https://github.com/cvg/DeepLSD/blob/52212738362711254f040c673276905c73b86ca5/deeplsd/geometry/line_utils.py#L431
-        # TODO: Make it parametrizable
-        # lines = merge_lines_torch(torch.tensor(lines)).int().cpu().numpy()
+    # Merge lines
+    indices_nms = merge_lines_torch(torch.tensor(lines), return_indices=True).int().cpu().numpy()
+    n_lines = points[indices_nms]
 
-        # Show lines and points
-        image = show_lines(image, lines)
-        image = show_points(image, points)
+    # Show lines and points
+    o_img = show_lines(image, lines[:, :, :2])
+    o_img = show_points(o_img, points)
 
-        folder_path = folder_path.split('/')[-1]
+    folder_path = folder_path.split('/')[-1]
 
-        print(f"Elapsed time for {folder_path} is : {end_time - start_time}")
+    # logger.info(f"Elapsed time for {folder_path} is : {end_time - start_time}")
 
-        plt.imshow(image)
-        if show:
-            plt.show()
+    plt.imshow(o_img)
+    if show:
+        plt.show()
 
-        plt.axis('off')
-        plt.savefig(f'tmp/{folder_path}.jpg', dpi=300,bbox_inches='tight', pad_inches=0)
-        plt.close()
+    plt.title("Before NMS")
+    plt.axis('off')
+    plt.savefig(f'tmp/{folder_path}_orig.jpg', dpi=300,bbox_inches='tight', pad_inches=0)
+    plt.close()
+
+    n_img = show_lines(image, n_lines)
+    n_img = show_points(n_img, points)
+
+    plt.imshow(n_img)
+    plt.title("After NMS")
+    plt.axis('off')
+    plt.savefig(f'tmp/{folder_path}_nms.jpg', dpi=300,bbox_inches='tight', pad_inches=0)
+    plt.close()
+
+    # Merge lines without indices
+    onms_lines = merge_lines_torch(torch.tensor(lines[:,:,:2]), return_indices=False).int().cpu().numpy()
+    print(f"Number of lines after orig NMS: {len(onms_lines)}")
+
+    onms_img = show_lines(image, onms_lines)
+    onms_img = show_points(onms_img, points)
+
+    plt.imshow(onms_img)
+    plt.title("After orig NMS")
+    plt.axis('off')
+    plt.savefig(f'tmp/{folder_path}_orig_nms.jpg', dpi=300,bbox_inches='tight', pad_inches=0)
+    plt.close()
 
 if __name__ == '__main__':
     from ... import logger
@@ -318,6 +337,4 @@ if __name__ == '__main__':
         os.system("rm -r tmp")
     os.makedirs("tmp", exist_ok=True)
 
-    for val in glob.glob(str(DATA_PATH / "revisitop1m_POLD2/**/base_image.jpg"), recursive=True):
-        logger.info(f"Processing {val}")
-        test_extractor(extractor, os.path.split(val)[0], extractor_conf.device, args.show)
+    for val in tqdm(glob.glob(str(DATA_PATH / "revisitop1m_POLD2/**/base_image.jpg"), recursive=True)):


### PR DESCRIPTION
Implementation of merging lines using NMS from DeepLSD computes the principal line direction for each connected component of lines, projects all merge candidate line endpoints onto the principal direction vector and chooses the furthest two points as the line endpoints after merge.

To ensure a wireframe like structure at the output of line extraction i.e. line endpoints are a subset of the detected keypoints, this PR modifies NMS to return keypoint indices after line merging instead of the endpoints. After projection onto the principal direction vector, the keypoint (indices) that lead to the furthest points after projection are returned.

Major updates in `gluefactory/models/lines/line_refinement.py`.