### PR TITLE
Refactoring for line extractor with nms usage

### DIFF
--- a/gluefactory/eval/hpatches_extended.py
+++ b/gluefactory/eval/hpatches_extended.py
@@ -89,17 +89,7 @@ def export_predictions(
                 scales = 1.0 / (
                     data["scales"] if len(idx) == 0 else data[f"view{idx}"]["scales"]
                 )
-                # comment for POLD2, uncomment for SP+LSD
-                if (len(pred[f"keypoints{idx}"][0].shape)) == 3:
-                    pred[k] = pred[k] * scales[None]
-                else:
-                    pred[k] = (
-                        # For JPLDD Line detection
-                        # (pred[f"keypoints{idx}"][0][pred[k][0][:,2].to(torch.int32)].reshape(1, -1, 2))
-                        (pred[f"keypoints{idx}"][0][pred[k]].reshape(1, -1, 2))
-                        .reshape(-1, 2, 2)
-                        .unsqueeze(0)
-                    )
+                pred[k] = pred[k] * scales[None]
             if k.startswith("orig_lines"):
                 idx = k.replace("orig_lines", "")
                 scales = 1.0 / (

--- a/gluefactory/eval/megadepth1500_extended.py
+++ b/gluefactory/eval/megadepth1500_extended.py
@@ -68,14 +68,7 @@ def export_predictions(
                 scales = 1.0 / (
                     data["scales"] if len(idx) == 0 else data[f"view{idx}"]["scales"]
                 )
-                if (len(pred[f"keypoints{idx}"][0].shape)) == 3:
-                    pred[k] = pred[k] * scales[None]
-                else:
-                    pred[k] = (
-                        (pred[f"keypoints{idx}"][0][pred[k]].reshape(1, -1, 2))
-                        .reshape(-1, 2, 2)
-                        .unsqueeze(0)
-                    )
+                pred[k] = pred[k] * scales[None]
             if k.startswith("orig_lines"):
                 idx = k.replace("orig_lines", "")
                 scales = 1.0 / (

--- a/gluefactory/models/lines/line_refinement.py
+++ b/gluefactory/models/lines/line_refinement.py
@@ -71,6 +71,7 @@ def merge_line_cluster_torch(lines, return_indices=False):
     Returns:
         The merged (2, 2) torch tensor line segment.
     """
+    device = lines.device
     orig_lines = lines
     lines = orig_lines[:, :, :2]
 
@@ -92,10 +93,10 @@ def merge_line_cluster_torch(lines, return_indices=False):
     a, b, c = cov[0, 0], cov[0, 1], cov[1, 1]
     # Principal component of a 2x2 symmetric matrix
     if b == 0:
-        u = torch.tensor([1, 0]) if a >= c else torch.tensor([0, 1])
+        u = torch.tensor([1, 0], device=device) if a >= c else torch.tensor([0, 1])
     else:
         m = (c - a + torch.sqrt((a - c) ** 2 + 4 * b**2)) / (2 * b)
-        u = torch.tensor([1, m]) / torch.sqrt(1 + m**2)
+        u = torch.tensor([1, m], device=device) / torch.sqrt(1 + m**2)
 
     # Get the center of gravity of all endpoints
     cross = torch.mean(points.float(), dim=0)
@@ -200,7 +201,7 @@ def merge_lines_torch(lines, thresh=5.0, overlap_thresh=0.0, return_indices=Fals
         adjacency_mat = ((overlaps > 0) | (close_endpoint < overlap_thresh)) * (
             orth_dist < thresh
         )
-    n_comp, components = connected_components(adjacency_mat, directed=False)
+    n_comp, components = connected_components(adjacency_mat.cpu(), directed=False)
 
     # For each cluster, merge all lines into a single one
     new_lines = []

--- a/gluefactory/models/lines/pold2_extractor.py
+++ b/gluefactory/models/lines/pold2_extractor.py
@@ -229,10 +229,10 @@ class LineExtractor(BaseModel):
 
         # Sample points
         if use_df:
-            df_vals = self.sample_map(points_coordinates, distance_map).view(self.num_sample_strong, -1)
+            df_vals = self.sample_map(points_coordinates, distance_map).view(self.num_sample_strong*num_bands, -1)
             
         if use_af:
-            af_vals = self.sample_map(points_coordinates, angle_map).view(self.num_sample_strong, -1)
+            af_vals = self.sample_map(points_coordinates, angle_map).view(self.num_sample_strong*num_bands, -1)
             
         # Prepare input for MLP
         if use_df and use_af:

--- a/gluefactory/models/lines/pold2_extractor.py
+++ b/gluefactory/models/lines/pold2_extractor.py
@@ -313,6 +313,8 @@ class LineExtractor(BaseModel):
             lines = points[filtered_idx]
 
             # Append indices to lines - (N,2,3)
+            # Lines are now in the form (x1, y1, idx1), (x2, y2, idx2), where idx1 and idx2 are the indices of the keypoints
+            # and (x1, y1) and (x2, y2) are the coordinates of the keypoints
             lines = torch.cat([lines.reshape(-1,2), filtered_idx.reshape(-1,1)], axis=-1).reshape(-1, 2, 3)
             filtered_idx = merge_lines_torch(torch.tensor(lines), return_indices=True).int()
 

--- a/gluefactory/models/matchers/nn_point_line.py
+++ b/gluefactory/models/matchers/nn_point_line.py
@@ -232,31 +232,9 @@ class NearestNeighborPointLineMatcher(BaseModel):
             lm1 = np.array([])
             lms0 = np.array([])
             lms1 = np.array([])
-            desc1 = torch.stack(
-                # For JPLDD line detection
-                # [
-                #     data["descriptors0"][batch_idx][data["lines0"][batch_idx][:,2, 0].int()],
-                #     data["descriptors0"][batch_idx][data["lines0"][batch_idx][:,2, 1].int()],
-                # ],
-                [
-                    data["descriptors0"][batch_idx][data["lines0"][batch_idx][:, 0]],
-                    data["descriptors0"][batch_idx][data["lines0"][batch_idx][:, 1]],
-                ],
-                1,
-            )
 
-            desc2 = torch.stack(
-                # For JPLDD line detection
-                # [
-                #     data["descriptors1"][batch_idx][data["lines1"][batch_idx][:,2, 0].int()],
-                #     data["descriptors1"][batch_idx][data["lines1"][batch_idx][:,2, 1].int()],
-                # ],
-                [
-                    data["descriptors1"][batch_idx][data["lines1"][batch_idx][:, 0]],
-                    data["descriptors1"][batch_idx][data["lines1"][batch_idx][:, 1]],
-                ],
-                1,
-            )
+            desc1 = data["line_descriptors0"][batch_idx]
+            desc2 = data["line_descriptors1"][batch_idx]
 
             if DEBUG:
                 print(f"lines0 : {data['lines0'][batch_idx].shape}")

--- a/notebooks/jpldd_linedet_testbed.py
+++ b/notebooks/jpldd_linedet_testbed.py
@@ -1,0 +1,97 @@
+from gluefactory.models import get_model
+from gluefactory.datasets import get_dataset
+import torch
+import random
+
+if torch.cuda.is_available():
+    device = 'cuda'
+elif torch.backends.mps.is_built():
+    device = 'mps'
+else:
+    device = 'cpu'
+
+print(f"Device Used: {device}")
+
+jpldd_conf = {
+    "name": "joint_point_line_extractor",
+    "max_num_keypoints": 500,  # setting for training, for eval: -1
+    "timeit": True,  # override timeit: False from BaseModel
+    "line_df_decoder_channels": 32,
+    "line_af_decoder_channels": 32,
+    "line_detection": {
+        "do": True,
+        "conf": {
+            "num_sample": 8,
+            "num_sample_strong": 150,
+            "max_point_size": 1500,
+
+        "distance_map": {
+            "threshold": 0.5,
+            "avg_filter_size": 13,
+            "avg_filter_padding": 6,
+            "avg_filter_stride": 1,
+            "max_value": 2,
+            "inlier_ratio": 0.8,
+            "mean_value_ratio": 0.8
+        },
+
+        "mlp_conf": {
+            "has_angle_field": True,
+            "has_distance_field": True, 
+            "num_line_samples": 30,    # number of sampled points between line endpoints
+            "mlp_hidden_dims": [256, 128, 128, 64, 32],
+            "pred_threshold": 0.9,
+            "weights": "/local/home/Point-Line/outputs/training/pold2_mlp_1k_img/checkpoint_best.tar",
+        }
+        }
+    },
+    "checkpoint": "/local/home/Point-Line/outputs/training/focal_loss_experiments/rk_focal_threshDF_focal/checkpoint_best.tar"
+    #"checkpoint": "/local/home/rkreft/shared_team_folder/outputs/training/rk_oxparis_focal_hard_gt/checkpoint_best.tar"
+    #"checkpoint": "/local/home/rkreft/shared_team_folder/outputs/training/rk_pold2gt_oxparis_base_hard_gt/checkpoint_best.tar"
+}
+jpldd_model = get_model("joint_point_line_extractor")(jpldd_conf).to(device)
+jpldd_model.eval()
+
+
+## Dataset
+dset_conf = {
+            "reshape": [400, 400], # ex [800, 800]
+            "load_features": {
+                "do": True,
+                "check_exists": True,
+                "point_gt": {
+                    "data_keys": ["superpoint_heatmap"],
+                    "use_score_heatmap": False,
+                },
+                "line_gt": {
+                    "data_keys": ["deeplsd_distance_field", "deeplsd_angle_field"],
+                },
+            },
+            "debug": True
+        }
+oxpa_2 = get_dataset("oxford_paris_mini_1view_jpldd")(dset_conf)
+ds = oxpa_2.get_dataset(split="train")
+
+# load one test element
+elem = ds[0]
+print(f"Keys: {elem.keys()}")
+
+# print example shapes
+af = elem["deeplsd_angle_field"]
+df = elem["deeplsd_distance_field"]
+hmap = elem["superpoint_heatmap"]
+orig_pt = elem["orig_points"]
+
+print(f"AF: type: {type(af)}, shape: {af.shape}, min: {torch.min(af)}, max: {torch.max(af)}")
+print(f"DF: type: {type(df)}, shape: {df.shape}, min: {torch.min(df)}, max: {torch.max(df)}")
+print(f"KP-HMAP: type: {type(hmap)}, shape: {hmap.shape}, min: {torch.min(hmap)}, max: {torch.max(hmap)}, sum: {torch.sum(hmap)}")
+
+## Inference
+rand_idx = random.sample(range(0, len(ds)), 300) 
+
+for i in rand_idx:
+    img_torch = ds[i]["image"].to(device).unsqueeze(0)
+    with torch.no_grad():
+        output_model = jpldd_model({"image": img_torch})
+        print(output_model['keypoints'].shape)
+        break

--- a/notebooks/jpldd_linedet_testbed.py
+++ b/notebooks/jpldd_linedet_testbed.py
@@ -1,3 +1,9 @@
+"""
+Testbed for Joint Point-Line Detection Model (JPLDD) with Line Detection.
+Replication of notebooks/refine_line_detection.ipynb as a python script instead of a notebook.
+"""
+
+
 from gluefactory.models import get_model
 from gluefactory.datasets import get_dataset
 import torch


### PR DESCRIPTION
Refactoring of the Line Detection module to include NMS.
Changes inlcude:

- Removing indexing of keypoints using indices, and use line endpoint coordinates instead as line representation in `gluefactory/eval/hpatches_extended.py` and `gluefactory/eval/megadepth1500_extended.py`.
- Update JPLDD [pass keypoint descriptors, return lines as endpoint coordinate pairs instead of keypoint indices, return lines and valid lines as torch tensors instead of lists] in `gluefactory/models/extractors/joint_point_line_extractor.py`.
- Minor fixes in `gluefactory/models/lines/line_refinement.py` to ensure GPU usage for line NMS
- Update `gluefactory/models/lines/pold2_extractor.py` to 
    - Apply NMS on output lines depending on config flag `use_nms`
    - Return `lines` as endpoint coordinates instead of keypoint indices
- Update `gluefactory/models/matchers/nn_point_line.py` to access line descriptors directly from model output dictionary instead of indexing keypoint descriptors