### PR TITLE
Border erosion for RDNIM benchmarks

### DIFF
--- a/gluefactory/configs/eval/jpldd+BF.yaml
+++ b/gluefactory/configs/eval/jpldd+BF.yaml
@@ -112,3 +112,13 @@ benchmarks:
         max_num_keypoints: 512 # overwrite config above
     use_points: False
     use_lines: True
+  rdnim_lines:
+    model:
+      extractor:
+        max_num_keypoints: 1024
+    data:
+      preprocessing:
+        resize: 800
+        side: long
+    use_points: False
+    use_lines: True

--- a/gluefactory/datasets/rdnim.py
+++ b/gluefactory/datasets/rdnim.py
@@ -81,16 +81,18 @@ class RDNIM(BaseDataset, torch.utils.data.Dataset):
 
         # get mask for black pixels in the image to identify synthetic borders
         np_img = read_image(self._files[idx][type], self.conf.grayscale)
-        mask = ~np.all(np_img == 0, axis=2)
+        padding_mask = ~np.all(np_img == 0, axis=2)
 
         # erode the mask to remove synthetic borders
         ks = self.conf.erosion_kernel_size
-        mask = cv2.erode(mask.astype(np.uint8), np.ones((ks, ks), np.uint8), iterations=1)
-        mask = torch.tensor(mask)[None]    # add channel dimension, 1xHxW
+        padding_mask = cv2.erode(padding_mask.astype(np.uint8), np.ones((ks, ks), np.uint8), iterations=1)
+        
+        padding_mask = torch.tensor(padding_mask)[None]    # add channel dimension, 1xHxW
         data_dict = self.preprocessor(img)
+
         # Preprocess mask the same way to have it rescaled
-        mask_dict = self.preprocessor(mask)
-        data_dict['mask'] = mask_dict["image"]
+        mask_dict = self.preprocessor(padding_mask)
+        data_dict['padding_mask'] = mask_dict["image"]
 
         return data_dict
 

--- a/gluefactory/datasets/rdnim.py
+++ b/gluefactory/datasets/rdnim.py
@@ -86,10 +86,11 @@ class RDNIM(BaseDataset, torch.utils.data.Dataset):
         # erode the mask to remove synthetic borders
         ks = self.conf.erosion_kernel_size
         mask = cv2.erode(mask.astype(np.uint8), np.ones((ks, ks), np.uint8), iterations=1)
-        mask = torch.tensor(mask, dtype=torch.int)[None]    # add channel dimension, 1xHxW
-
+        mask = torch.tensor(mask)[None]    # add channel dimension, 1xHxW
         data_dict = self.preprocessor(img)
-        data_dict['mask'] = mask
+        # Preprocess mask the same way to have it rescaled
+        mask_dict = self.preprocessor(mask)
+        data_dict['mask'] = mask_dict["image"]
 
         return data_dict
 

--- a/gluefactory/datasets/rdnim.py
+++ b/gluefactory/datasets/rdnim.py
@@ -8,7 +8,7 @@ import cv2
 from pathlib import Path
 from gluefactory.datasets import BaseDataset
 import zipfile
-from gluefactory.utils.image import ImagePreprocessor, load_image
+from gluefactory.utils.image import ImagePreprocessor, load_image, read_image
 from gluefactory.datasets.base_dataset import BaseDataset
 from gluefactory.datasets.utils import read_timestamps
 from gluefactory.settings import DATA_PATH
@@ -20,7 +20,8 @@ class RDNIM(BaseDataset, torch.utils.data.Dataset):
         'preprocessing': ImagePreprocessor.default_conf,
         'data_dir': 'RDNIM',
         'reference': 'day',
-        'grayscale': False
+        'grayscale': False,
+        'erosion_kernel_size': 15
     }
 
     url = "https://cvg-data.inf.ethz.ch/RDNIM/RDNIM.zip"
@@ -77,7 +78,20 @@ class RDNIM(BaseDataset, torch.utils.data.Dataset):
 
     def _read_image(self, idx: int, type: str) -> dict:
         img = load_image(self._files[idx][type], self.conf.grayscale)
-        return self.preprocessor(img)
+
+        # get mask for black pixels in the image to identify synthetic borders
+        np_img = read_image(self._files[idx][type], self.conf.grayscale)
+        mask = ~np.all(np_img == 0, axis=2)
+
+        # erode the mask to remove synthetic borders
+        ks = self.conf.erosion_kernel_size
+        mask = cv2.erode(mask.astype(np.uint8), np.ones((ks, ks), np.uint8), iterations=1)
+        mask = torch.tensor(mask, dtype=torch.int)[None]    # add channel dimension, 1xHxW
+
+        data_dict = self.preprocessor(img)
+        data_dict['mask'] = mask
+
+        return data_dict
 
     def __getitem__(self, idx: int) -> dict:
         img0 = self._read_image(idx,"ref")

--- a/gluefactory/models/extractors/joint_point_line_extractor.py
+++ b/gluefactory/models/extractors/joint_point_line_extractor.py
@@ -320,6 +320,8 @@ class JointPointLineDetectorDescriptor(BaseModel):
         keypoint_and_junction_score_map = padder.unpad(
             score_map_padded
         )  # B x 1 x H x W
+        if 'mask' in data:
+            keypoint_and_junction_score_map *= data['mask'].float()
 
         # For storing, remove additional dimension but keep batch dimension even if its 1
         # but keep additional dimension for variable -> needed by dkd

--- a/gluefactory/models/extractors/joint_point_line_extractor.py
+++ b/gluefactory/models/extractors/joint_point_line_extractor.py
@@ -320,8 +320,8 @@ class JointPointLineDetectorDescriptor(BaseModel):
         keypoint_and_junction_score_map = padder.unpad(
             score_map_padded
         )  # B x 1 x H x W
-        if 'mask' in data:
-            keypoint_and_junction_score_map *= data['mask'].float()
+        if 'padding_mask' in data:
+            keypoint_and_junction_score_map *= data['padding_mask'].float()
 
         # For storing, remove additional dimension but keep batch dimension even if its 1
         # but keep additional dimension for variable -> needed by dkd

--- a/gluefactory/models/lines/pold2_extractor.py
+++ b/gluefactory/models/lines/pold2_extractor.py
@@ -322,6 +322,8 @@ class LineExtractor(BaseModel):
         points_coordinates = self.get_coordinates(
             points, indices, self.coeffs_list[sample_idx], self.coeffs_second_list[sample_idx]
         )
+        points_coordinates[:, 0] = torch.clamp(points_coordinates[:, 0], 0, distance_map.shape[1] - 1)
+        points_coordinates[:, 1] = torch.clamp(points_coordinates[:, 1], 0, distance_map.shape[0] - 1)
 
         # Sample points
         binary_df_sampled = self.sample_map(


### PR DESCRIPTION
The RDNIM dataset contains strong homography transformations that lead to significant border artifacts in the warped images. This makes the point-line extractor susceptible to detecting keypoints and lines on the synthetic borders in the warped image. To prevent this, we calculate a mask in the dataloader that denotes all the valid pixels in the image that should be considered as keypoint candidates. We multiply the score_map generated by the extractor with the mask and then continue with NMS, keypoint detection and line detection.
